### PR TITLE
Support chaining syntax in `9-thenable`

### DIFF
--- a/JavaScript/9-thenable.js
+++ b/JavaScript/9-thenable.js
@@ -18,11 +18,10 @@ class Thenable {
   resolve(value) {
     const fn = this.fn;
     if (fn) {
-      const next = fn(value);
-      if (next) {
-        next.then((value) => {
-          this.next.resolve(value);
-        });
+      const result = fn(value);
+      const next = this.next;
+      if (next.fn) {
+        next.resolve(result);
       }
     }
   }
@@ -39,8 +38,11 @@ const readFile = (filename) => {
   return thenable;
 };
 
+const MINIFY_REGEX = new RegExp('\\s+', 'g');
+const minify = (content) => content.replaceAll(MINIFY_REGEX, '');
+
 const main = async () => {
-  const file1 = await readFile('9-thenable.js');
+  const file1 = await readFile('9-thenable.js').then(minify);
   console.dir({ length: file1.length });
 };
 


### PR DESCRIPTION
The current implementation of `resolve` in `Thenable` has a major flaw and does not support chaining syntax. It throws an error once called with additional `.then`:
```
TypeError: next.then is not a function
```

I was going to add some comments to https://github.com/HowProgrammingWorks/AsyncAwait/pull/4, where this issue had been addressed, but the author seems to have been inactive for the last few years, so I decided to create a new pull request.

The reason for the problem is that the local `next` variable is actually the result of the current resolve function, and not the next `Thenable` instance.

Such naming also inspired another problem. If the result of the current resolve function has a falsy value it will not pass `if (next)` and the whole following chain will be omitted.

I fixed the `resolve` logic to support additional chains and extended the usage example to prove it does work.